### PR TITLE
add __pycache__ folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ settings.conf
 dist/
 build/
 *.spec
+__pycache__
+*/__pycache__


### PR DESCRIPTION
stop git to handle __pycache__ folders that are being generated when running IntelPy.py manually